### PR TITLE
added support for preferences update

### DIFF
--- a/lib/quickbooks/model/preferences.rb
+++ b/lib/quickbooks/model/preferences.rb
@@ -6,11 +6,13 @@ module Quickbooks
       REST_RESOURCE       = 'preferences'
 
       xml_name XML_NODE
+      xml_accessor :id, :from => 'Id'
+      xml_accessor :sync_token, :from => 'SyncToken', :as => Integer
 
       def self.create_preference_class(*attrs, &block)
         ::Class.new(BaseModel) do
           attrs.each do |a|
-            xml_reader(a.underscore, :from => a.gsub("?", ""))
+            xml_accessor(a.underscore, :from => a.gsub("?", ""))
           end
           instance_eval(&block) if block_given?
         end
@@ -19,14 +21,13 @@ module Quickbooks
       PREFERENCE_SECTIONS = {
         :accounting_info      => %w(TrackDepartments DepartmentTerminology ClassTrackingPerTxnLine? ClassTrackingPerTxn? CustomerTerminology),
         :product_and_services => %w(ForSales? ForPurchase? QuantityWithPriceAndRate? QuantityOnHand?),
-        :vendor_and_purchase  => %w(TrackingByCustomer? BillableExpenseTracking? DefaultTerms? DefaultMarkup? POCustomField),
         :time_tracking        => %w(UseServices? BillCustomers? ShowBillRateToAll WorkWeekStartDate MarkTimeEntiresBillable?),
         :tax                  => %w(UsingSalesTax? PartnerTaxEnabled?),
         :currency             => %w(MultiCurrencyEnabled? HomeCurrency),
         :report               => %w(ReportBasis)
       }
 
-      xml_reader :sales_forms, :from => "SalesFormsPrefs", :as => create_preference_class(*%w(
+      xml_accessor :sales_forms, :from => "SalesFormsPrefs", :as => create_preference_class(*%w(
         AllowDeposit?
         AllowDiscount?
         AllowEstimates?
@@ -50,15 +51,27 @@ module Quickbooks
         UsingPriceLevels?
         UsingProgressInvoicing?
       )) {
-        xml_reader :custom_fields, :as => [CustomField], :from => 'CustomField', in: 'CustomField'
+        xml_name "SalesFormsPrefs"
+        # xml_reader :custom_fields, :as => [CustomField], :from => 'CustomField', in: 'CustomField'
+      }
+
+      xml_reader :vendor_and_purchases, :from => "VendorAndPurchasesPrefs", :as => create_preference_class(*%w(
+        TrackingByCustomer?
+        BillableExpenseTracking?
+        DefaultTerms?
+        DefaultMarkup?
+      )) {
+        xml_name "VendorAndPurchasesPrefs"
+        # xml_reader :po_custom_fields, :as => [CustomField], :from => 'CustomField', in: 'POCustomField'
       }
 
       PREFERENCE_SECTIONS.each do |section_name, fields|
-        xml_reader section_name, :from => "#{section_name}_prefs".camelize, :as => create_preference_class(*fields)
+        xml_reader section_name, :from => "#{section_name}_prefs".camelize, :as => create_preference_class(*fields) { xml_name "#{section_name}_prefs" }
       end
 
-      EmailMessage          = create_preference_class("Subject", "Message")
+      EmailMessage          = create_preference_class("Subject", "Message") { xml_name "EmailMessage" }
       EmailMessageContainer = create_preference_class do
+        xml_name "EmailMessageContainer"
         %w(InvoiceMessage EstimateMessage SalesReceiptMessage StatementMessage).each do |msg|
           xml_reader msg.underscore, :from => msg, :as => EmailMessage
         end
@@ -66,7 +79,11 @@ module Quickbooks
 
       xml_reader :email_messages, :from => "EmailMessagesPrefs", as: EmailMessageContainer
 
-      xml_reader :other_prefs, :from => "OtherPrefs/NameValue", :as => { :key => "Name", :value => "Value" }
+      OtherPrefs = create_preference_class do
+        xml_name "OtherPrefs"
+        xml_reader :name_values, :from => 'NameValue', :as => { :key => "Name", :value => "Value" }
+      end
+      xml_reader :other_prefs, :from => "OtherPrefs", :as => OtherPrefs
     end
 
   end

--- a/spec/fixtures/preferences_query.xml
+++ b/spec/fixtures/preferences_query.xml
@@ -1,5 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <IntuitResponse xmlns="http://schema.intuit.com/finance/v3" time="2019-12-05T09:50:38.974-08:00">
-  <QueryResponse maxResults="1">
     <Preferences domain="QBO" sparse="false">
       <Id>1</Id>
       <SyncToken>3</SyncToken>
@@ -234,5 +234,4 @@ Craig's Design and Landscaping Services</Message>
         </NameValue>
       </OtherPrefs>
     </Preferences>
-  </QueryResponse>
 </IntuitResponse>

--- a/spec/lib/quickbooks/model/preferences_spec.rb
+++ b/spec/lib/quickbooks/model/preferences_spec.rb
@@ -14,10 +14,19 @@ describe "Quickbooks::Model::Preferences" do
     expect(preferences.email_messages.estimate_message.message).to include("We look forward to working with you.")
 
     expect(preferences.sales_forms.auto_apply_credit?).to be true
-    expect(preferences.sales_forms.custom_fields).not_to be_empty
-    expect(preferences.sales_forms.custom_fields[0].name).to eq("SalesFormsPrefs.UseSalesCustom1")
-    expect(preferences.sales_forms.custom_fields[3].name).to eq("SalesFormsPrefs.SalesCustomName1")
+    # expect(preferences.sales_forms.custom_fields).not_to be_empty
+    # expect(preferences.sales_forms.custom_fields[0].name).to eq("SalesFormsPrefs.UseSalesCustom1")
+    # expect(preferences.sales_forms.custom_fields[3].name).to eq("SalesFormsPrefs.SalesCustomName1")
+    
+    expect(preferences.other_prefs.name_values["SalesFormsPrefs.DefaultItem"]).to eq("1")
+  end
 
-    expect(preferences.other_prefs["SalesFormsPrefs.DefaultItem"]).to eq("1")
+  it "is valid pref" do
+    xml = fixture("preferences.xml")
+    pref = Quickbooks::Model::Preferences.from_xml(xml)
+    pref.sales_forms.allow_shipping=true
+
+    expect(pref.valid?).to be true
+    expect(pref.sales_forms.allow_shipping?).to be true
   end
 end

--- a/spec/lib/quickbooks/service/preferences_spec.rb
+++ b/spec/lib/quickbooks/service/preferences_spec.rb
@@ -13,6 +13,20 @@ describe "Quickbooks::Service::Preferences" do
 
     preferences = preferences_query.entries.first
     expect(preferences.accounting_info.customer_terminology).to eq("Customers")
+    expect(preferences.vendor_and_purchases.tracking_by_customer?).to eq true
   end
+  
+  it "can sparse update a preferences" do
 
+    xml = fixture("preferences_query.xml")
+    model = Quickbooks::Model::Preferences
+
+    stub_http_request(:get, @service.url_for_query, ["200", "OK"], xml)
+    preferences = @service.query.first
+    preferences.sales_forms.allow_shipping=false
+
+    stub_http_request(:post, @service.url_for_resource(model::REST_RESOURCE), ["200", "OK"], xml)
+    response = @service.update(preferences, :sparse => true)
+    expect(response.sales_forms.allow_shipping?).to eq false
+  end
 end


### PR DESCRIPTION
Summary
- Added ability to update the Preferences --> Sales_forms --> allow_shipping flag.
- Commented the CustomFields & POCustomFields 
- Fixed the "vendor and purchases" fields

Motivation/Context
https://jira.intuit.com/browse/QBCO-1491