### PR TITLE
[BUGFIX] Dont send ForSales and ForPurchase attributes

### DIFF
--- a/lib/quickbooks/model/preferences.rb
+++ b/lib/quickbooks/model/preferences.rb
@@ -20,7 +20,7 @@ module Quickbooks
 
       PREFERENCE_SECTIONS = {
         :accounting_info      => %w(TrackDepartments DepartmentTerminology ClassTrackingPerTxnLine? ClassTrackingPerTxn? CustomerTerminology),
-        :product_and_services => %w(ForSales? ForPurchase? QuantityWithPriceAndRate? QuantityOnHand?),
+        :product_and_services => %w(QuantityWithPriceAndRate? QuantityOnHand?),
         :time_tracking        => %w(UseServices? BillCustomers? ShowBillRateToAll WorkWeekStartDate MarkTimeEntiresBillable?),
         :tax                  => %w(UsingSalesTax? PartnerTaxEnabled?),
         :currency             => %w(MultiCurrencyEnabled? HomeCurrency),

--- a/spec/fixtures/preferences.xml
+++ b/spec/fixtures/preferences.xml
@@ -16,8 +16,6 @@
     <CustomerTerminology>Customers</CustomerTerminology>
   </AccountingInfoPrefs>
   <ProductAndServicesPrefs>
-    <ForSales>true</ForSales>
-    <ForPurchase>false</ForPurchase>
     <QuantityWithPriceAndRate>true</QuantityWithPriceAndRate>
     <QuantityOnHand>false</QuantityOnHand>
   </ProductAndServicesPrefs>

--- a/spec/fixtures/preferences_query.xml
+++ b/spec/fixtures/preferences_query.xml
@@ -18,8 +18,6 @@
         <CustomerTerminology>Customers</CustomerTerminology>
       </AccountingInfoPrefs>
       <ProductAndServicesPrefs>
-        <ForSales>true</ForSales>
-        <ForPurchase>true</ForPurchase>
         <QuantityWithPriceAndRate>true</QuantityWithPriceAndRate>
         <QuantityOnHand>true</QuantityOnHand>
       </ProductAndServicesPrefs>


### PR DESCRIPTION
QBO seems to generate initial prefs with conflicting properties related
to these attributes. By disabling these attributes, we should ideally
not hit any conflicts that QBO prefs internally generate.