### PR TITLE
[FEATURE] Added ShippingTaxIncludedInTotalTax field in the credit memo model

### DIFF
--- a/lib/quickbooks/model/credit_memo.rb
+++ b/lib/quickbooks/model/credit_memo.rb
@@ -40,6 +40,7 @@ module Quickbooks
       xml_accessor :balance, :from => 'Balance', :as => BigDecimal, :to_xml => to_xml_big_decimal
       xml_accessor :remaining_credit, :from => 'RemainingCredit', :as => BigDecimal, :to_xml => to_xml_big_decimal
       xml_accessor :txn_source, :from => 'TxnSource'
+      xml_accessor :shipping_tax_included_in_total_tax?, :from => 'ShippingTaxIncludedInTotalTax'
 
       # readonly
       xml_accessor :total, :from => 'TotalAmt', :as => BigDecimal

--- a/spec/fixtures/credit_memo.xml
+++ b/spec/fixtures/credit_memo.xml
@@ -7,6 +7,7 @@
   </MetaData>
   <DocNumber>R3454653464</DocNumber>
   <TxnSource>SOURCENAME</TxnSource>
+  <ShippingTaxIncludedInTotalTax>true</ShippingTaxIncludedInTotalTax>
   <TxnDate>2013-12-17</TxnDate>
   <CurrencyRef name="Brazilian Real">BRL</CurrencyRef>
   <Line>

--- a/spec/lib/quickbooks/model/credit_memo_spec.rb
+++ b/spec/lib/quickbooks/model/credit_memo_spec.rb
@@ -27,6 +27,7 @@ describe "Quickbooks::Model::CreditMemo" do
     credit_memo = Quickbooks::Model::CreditMemo.from_xml(xml)
     expect(credit_memo.id).to eq "52"
     expect(credit_memo.txn_source).to eq 'SOURCENAME'
+    expect(credit_memo.shipping_tax_included_in_total_tax?).to be true
   end
 
   describe "#auto_doc_number" do


### PR DESCRIPTION
Summary
To support the tax toggle changes (prevent double counting) for credit memo synced from QBC to QBO, added the ShippingTaxIncludedInTotalTax field in the credit memo model.

Motivation/Context
https://jira.intuit.com/browse/QBCO-2187