### PR TITLE
[FIX] removing Sales price from non shipping Adjustment line item

### DIFF
--- a/lib/quickbooks/model/item_adjustment_line_detail.rb
+++ b/lib/quickbooks/model/item_adjustment_line_detail.rb
@@ -6,7 +6,7 @@ module Quickbooks
       xml_accessor :qty_diff, from: 'QtyDiff'
       xml_accessor :item_ref, from: 'ItemRef', as: BaseReference
       xml_accessor :class_ref, from: 'ClassRef', as: BaseReference
-      xml_accessor :sales_price, from: 'SalesPrice', as: BigDecimal, to_xml: proc { |val| val.to_f }
+      xml_accessor :sales_price, from: 'SalesPrice', as: BigDecimal, to_xml: proc { |val| val.nil? ? nil : val.to_f }
 
       reference_setters :item_ref, :class_ref
     end

--- a/spec/lib/quickbooks/model/inventory_adjustment_spec.rb
+++ b/spec/lib/quickbooks/model/inventory_adjustment_spec.rb
@@ -50,6 +50,30 @@ describe 'Quickbooks::Model::InventoryAdjustment' do
     expect(inventory_adjustment.valid?).to be true
   end
 
+  it 'validates basic setup for non-shipping adj' do
+    inventory_adjustment = Quickbooks::Model::InventoryAdjustment.new
+    inventory_adjustment.id = 1
+    inventory_adjustment.sync_token = 0
+    inventory_adjustment.doc_number = 'test DNum'
+    inventory_adjustment.private_note = 'Private note'
+    inventory_adjustment.txn_date = '2021-05-27 16:52:20 UTC'
+    inventory_adjustment.shipping_adjustment = true
+    inventory_adjustment.txn_source = 'SOMESOURCE'
+    line_item = Quickbooks::Model::Line.new
+    line_item.detail_type = 'ItemAdjustmentLineDetail'
+    line_item.inventory_adjustment!
+    line_item.item_adjustment_line_detail.qty_diff = -5
+    line_item.item_adjustment_line_detail.item_ref = { "name": 'item17', "value": '21' }
+    inventory_adjustment.line_items << line_item
+
+    n = Nokogiri::XML(inventory_adjustment.to_xml.to_s)
+    expect(n.at('InventoryAdjustment > TxnSource').content).to eq('SOMESOURCE')
+    expect(n.at('InventoryAdjustment > Line > DetailType').content).to eq('ItemAdjustmentLineDetail')
+    expect(n.at('Line > ItemAdjustmentLineDetail > QtyDiff').content).to eq('-5')
+    expect(n.at('Line > ItemAdjustmentLineDetail > SalesPrice')).to eq(nil)
+    expect(inventory_adjustment.valid?).to be true
+  end
+
   it 'creates an entity reference' do
     inventory_adjustment = Quickbooks::Model::InventoryAdjustment.new
     line_item = Quickbooks::Model::Line.new


### PR DESCRIPTION
#### Description
Removing Sales price from non shipping Adjustment line item

#### Sample XML Request body
```
<InventoryAdjustment
	xmlns="http://schema.intuit.com/finance/v3" sparse="false">
	<AdjustAccountRef>9</AdjustAccountRef>
	<DocNumber>SalesOrder7-1</DocNumber>
	<TxnDate>2021-10-19</TxnDate>
	<PrivateNote>http://localhost:3000/orders/78/shipments/32</PrivateNote>
	<CustomerRef>1</CustomerRef>
	<Line>
		<DetailType>ItemAdjustmentLineDetail</DetailType>
		<ItemAdjustmentLineDetail>
			<QtyDiff>-1.0</QtyDiff>
			<ItemRef>4</ItemRef>
			<SalesPrice>500.0</SalesPrice>
		</ItemAdjustmentLineDetail>
	</Line>
	<ShippingAdjustment>true</ShippingAdjustment>
</InventoryAdjustment>
```
